### PR TITLE
fix(vue-i18n): Allow additional attributes on i18n component

### DIFF
--- a/src/frameworks/vue.ts
+++ b/src/frameworks/vue.ts
@@ -30,7 +30,7 @@ class VueFramework extends Framework {
 
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
-    '(?:i18n(?:-\\w+)?[ (\n]\\s*(?:\\w+\\s*=\\s*[\'"][^\'"]*[\'"]\\s*)?(?:key)?path=|v-t=[\'"`{]|(?:this\\.|\\$|i18n\\.|[^\\w\\d])(?:t|tc|te)\\()\\s*[\'"`]({key})[\'"`]'
+    '(?:i18n(?:-\\w+)?[ \\n]\\s*(?:\\w+=[\'"][^\'"]*[\'"][ \\n]\\s*)?(?:key)?path=|v-t=[\'"`{]|(?:this\\.|\\$|i18n\\.|[^\\w\\d])(?:t|tc|te)\\()\\s*[\'"`]({key})[\'"`]'
   ]
 
   refactorTemplates(keypath: string, args: string[] = [], doc?: TextDocument, detection?: DetectionResult) {

--- a/src/frameworks/vue.ts
+++ b/src/frameworks/vue.ts
@@ -30,7 +30,7 @@ class VueFramework extends Framework {
 
   // for visualize the regex, you can use https://regexper.com/
   usageMatchRegex = [
-    '(?:i18n(?:-\\w+)?[ (\n]\\s*(?:key)?path=|v-t=[\'"`{]|(?:this\\.|\\$|i18n\\.|[^\\w\\d])(?:t|tc|te)\\()\\s*[\'"`]({key})[\'"`]',
+    '(?:i18n(?:-\\w+)?[ (\n]\\s*(?:\\w+\\s*=\\s*[\'"][^\'"]*[\'"]\\s*)?(?:key)?path=|v-t=[\'"`{]|(?:this\\.|\\$|i18n\\.|[^\\w\\d])(?:t|tc|te)\\()\\s*[\'"`]({key})[\'"`]'
   ]
 
   refactorTemplates(keypath: string, args: string[] = [], doc?: TextDocument, detection?: DetectionResult) {


### PR DESCRIPTION
fixes #864

Is there a reason the `\n` is not escaped in the regex? All other occurrences of `\` are escaped.
Also: How do I add tests for this change?

// EDIT: I assume there was a typo in the rejex and the stray `(` in front of `\n` was meant to be an `\` so I changed it accordingly