### PR TITLE
feat: add support for `@jsverse/transloco`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
 
+### [2.12.1](https://github.com/lokalise/i18n-ally/compare/v2.12.0...v2.12.1) (2024-04-15)
+
+
+### ⚡ Features
+
+* add support for `@jsverse/transloco` ([c08c5a7](https://github.com/lokalise/i18n-ally/commit/c08c5a7942e46f32fceac4d134f361d697478517))
+
 ## [2.12.0](https://github.com/lokalise/i18n-ally/compare/v2.11.1...v2.12.0) (2023-09-23)
 
 ### ⚡ Features

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "publisher": "lokalise",
   "name": "i18n-ally",
-  "version": "2.12.0",
+  "version": "2.12.1",
   "displayName": "i18n Ally",
   "description": "🌍 All in one i18n extension for VS Code",
   "keywords": [

--- a/src/frameworks/transloco.ts
+++ b/src/frameworks/transloco.ts
@@ -10,6 +10,7 @@ export default class TranslocoFramework extends Framework {
   detection = {
     packageJSON: [
       '@ngneat/transloco',
+      '@jsverse/transloco',
     ],
   }
 


### PR DESCRIPTION
From version 7.0.0, the namespace for Transloco has been updated to `@jsverse`.

Detail: https://github.com/jsverse/transloco/blob/master/BREAKING_CHANGES.md#transloco-v7