### PR TITLE
allow custom framework use args in refactor templates

### DIFF
--- a/src/frameworks/custom.ts
+++ b/src/frameworks/custom.ts
@@ -77,9 +77,10 @@ class CustomFramework extends Framework {
 
   set monopoly(_) {}
 
-  refactorTemplates(keypath: string) {
+  refactorTemplates(keypath: string, args: string[] = []) {
     return (this.data?.refactorTemplates || ['$1'])
-      .map(i => i.replace(/\$1/g, keypath))
+      .filter(i => args.length || !i.includes('$2'))
+      .map(i => i.replace(/\$1/g, keypath).replace(/\$2/g, `[${args.join(',')}]`))
   }
 
   getScopeRange(document: TextDocument): ScopeRange[] | undefined {


### PR DESCRIPTION
now custom framework cannot use args in refactor templates.

with refactor template `i18n.t('$1')` in `i18n-ally-custom-framework.yml`,
when we extract text like `` `hello, ${'world'}` ``,
we will only get `i18n.t("<keypath of 'hello, {0}'>")`,
but we need `i18n.t("<keypath of 'hello, {0}'>", ['world'])`,
here is no way to do this now.

but with this patch, and config below, it will works as we need

```yaml
# i18n-ally-custom-framework.yml
refactorTemplates:
  - i18n.t('$1', $2)
  - i18n.t('$1')
```

notice: the first template with `$2` only used with args not empty, so we need a template without `$2` for fallback
