### PR TITLE
Support mapping will translate languages

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -68,6 +68,7 @@
   "config.keystyle": "Locale key style",
   "config.language_tag_system": "Language tag system use are using.",
   "config.libretranslate_api_root": "LibreTranslate API root URL",
+  "config.mapping_translation_locale": "Machine translation language mapping",
   "config.locale_country_map": "An object to map two letters locale code to country code",
   "config.locales_paths": "Path to locales directory (relative to project root). Glob pattern is also acceptable.",
   "config.namespace": "Enable namespaces. Check out the docs for more details.",

--- a/locales/zh-CN.json
+++ b/locales/zh-CN.json
@@ -70,6 +70,7 @@
   "config.libretranslate_api_root": "",
   "config.locale_country_map": "将两个字母的区域设置代码映射到国家/地区代码的对象",
   "config.locales_paths": "翻译文件夹路径 (相对于项目根目录)，你也可以使用Glob匹配模式。",
+  "config.mapping_translation_locale": "机器翻译语言映射",
   "config.namespace": "启用命名空间。查看文档了解更多详细信息。",
   "config.openai_api_key": "",
   "config.openai_api_model": "",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "publisher": "lokalise",
   "name": "i18n-ally",
-  "version": "2.13.1",
+  "version": "2.13.2",
   "displayName": "i18n Ally",
   "description": "🌍 All in one i18n extension for VS Code",
   "keywords": [
@@ -1079,6 +1079,11 @@
           "type": "string",
           "default": null,
           "description": "%config.baidu_appid%"
+        },
+        "i18n-ally.translate.target.map": {
+          "type": "object",
+          "default": {},
+          "description": "%config.mapping_translation_locale%"
         },
         "i18n-ally.translate.baidu.apiSecret": {
           "type": "string",

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -180,7 +180,7 @@ export class Config {
     return this.getConfig<SortCompare>('sortCompare') || 'binary'
   }
 
-  static get sortLocale(): string | undefined{
+  static get sortLocale(): string | undefined {
     return this.getConfig<string>('sortLocale')
   }
 
@@ -542,6 +542,10 @@ export class Config {
     return await workspace
       .getConfiguration(EXT_NAMESPACE)
       .update(key, value, isGlobal)
+  }
+
+  static get translateTargetMap() {
+    return this.getConfig<Record<string, string>>('translate.target.map') ?? {}
   }
 
   static get baiduApiSecret() {

--- a/src/core/Translator.ts
+++ b/src/core/Translator.ts
@@ -136,7 +136,7 @@ export class Translator {
         catch (err) {
           // eslint-disable-next-line no-console
           console.error(err)
-          failedJobs.push([job, err])
+          failedJobs.push([job, err as Error])
         }
         finished += 1
         progress.report({ increment, message })
@@ -254,9 +254,11 @@ export class Translator {
     const value = this.getValueOfKey(loader, keypath, source)
 
     try {
-      Log.info(`🌍 Translating "${keypath}" (${source}->${locale})`)
+      // In order to adapt to different machine translations. Here the target language is translated via map.
+      const target = Config.translateTargetMap[locale] ?? locale
+      Log.info(`🌍 Translating "${keypath}" (${source}->${target})`)
       this.start(keypath, locale)
-      const result = await this.translateText(value, source, locale)
+      const result = await this.translateText(value, source, target)
       this.end(keypath, locale)
 
       if (token?.isCancellationRequested)
@@ -318,7 +320,7 @@ export class Translator {
         break
       }
       catch (e) {
-        errors.push(e)
+        errors.push(e as Error)
       }
     }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2704,15 +2704,10 @@ caniuse-api@^3.0.0:
     lodash.memoize "^4.1.2"
     lodash.uniq "^4.5.0"
 
-caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001251:
-  version "1.0.30001251"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001251.tgz#6853a606ec50893115db660f82c094d18f096d85"
-  integrity sha512-HOe1r+9VkU4TFmnU70z+r7OLmtR+/chB1rdcJUeQlAinjEeb0cKL20tlAtOagNZhbrtLnCvV19B4FmF1rgzl6A==
-
-caniuse-lite@^1.0.30001565:
-  version "1.0.30001579"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001579.tgz#45c065216110f46d6274311a4b3fcf6278e0852a"
-  integrity sha512-u5AUVkixruKHJjw/pj9wISlcMpgFWzSrczLZbrqBSxukQixmg0SJ5sZTpvaFvxU0HoQKd4yoyAogyrAz9pzJnA==
+caniuse-lite@^1.0.0, caniuse-lite@^1.0.30001251, caniuse-lite@^1.0.30001565:
+  version "1.0.30001713"
+  resolved "https://registry.npmmirror.com/caniuse-lite/-/caniuse-lite-1.0.30001713.tgz"
+  integrity sha512-wCIWIg+A4Xr7NfhTuHdX+/FKh3+Op3LBbSp2N5Pfx6T/LhdQy3GTyoTg48BReaW/MyMNZAkTadsBtai3ldWK0Q==
 
 capital-case@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
i18n-ally is very good, but when I use machine translation, for example, I need to use Baidu API to translate the target into traditional characters, and the Chinese traditional Chinese code supported by Baidu is cht, not zh-TW, so the translation does not take effect. So I created this Pr and now we can make it work like this
```js
"i18n-ally.translate.target.map": {
  "zh-HK": "cht",
  "zh-TW": "cht",
}
```