### PR TITLE
feat: add config property openaiCustomApiModel

### DIFF
--- a/locales/en.json
+++ b/locales/en.json
@@ -73,6 +73,7 @@
   "config.namespace": "Enable namespaces. Check out the docs for more details.",
   "config.openai_api_key": "OpenAI API key",
   "config.openai_api_model": "OpenAI chatgpt model",
+  "config.openai_custom_api_model": "OpenAI custom chatgpt model",
   "config.openai_api_root": "OpenAI API root URL",
   "config.path_matcher": "Match path for custom locale/namespace. Check out the docs for more details.",
   "config.preferred_delimiter": "Preferred delimiter of composed keypath, default to \"-\"(dash)",

--- a/package.json
+++ b/package.json
@@ -1127,6 +1127,11 @@
           ],
           "description": "%config.openai_api_model%"
         },
+        "i18n-ally.translate.openai.customApiModel": {
+          "type": "string",
+          "default": null,
+          "description": "%config.openai_custom_api_model%"
+        },
         "i18n-ally.usage.scanningIgnore": {
           "type": "array",
           "items": {

--- a/src/core/Config.ts
+++ b/src/core/Config.ts
@@ -180,7 +180,7 @@ export class Config {
     return this.getConfig<SortCompare>('sortCompare') || 'binary'
   }
 
-  static get sortLocale(): string | undefined{
+  static get sortLocale(): string | undefined {
     return this.getConfig<string>('sortLocale')
   }
 
@@ -582,6 +582,10 @@ export class Config {
 
   static get openaiApiModel() {
     return this.getConfig<string>('translate.openai.apiModel') ?? 'gpt-3.5-turbo'
+  }
+
+  static get openaiCustomApiModel() {
+    return this.getConfig<string>('translate.openai.customApiModel') ?? ''
   }
 
   static get telemetry(): boolean {

--- a/src/translators/engines/openai.ts
+++ b/src/translators/engines/openai.ts
@@ -10,7 +10,7 @@ export default class OpenAITranslate extends TranslateEngine {
     let apiKey = Config.openaiApiKey;
     let apiRoot = this.apiRoot;
     if (Config.openaiApiRoot) apiRoot = Config.openaiApiRoot.replace(/\/$/, "");
-    let model = Config.openaiApiModel;
+    let model = Config.openaiCustomApiModel.length > 0 ? Config.openaiCustomApiModel : Config.openaiApiModel;
 
     const response = await axios.post(
       `${apiRoot}/v1/chat/completions`,


### PR DESCRIPTION
Added a config property `openaiCustomApiModel` which is a string that allows any input.
The existing `openaiApiModel` value is used if this is left blank or this will be used otherwise, regardless of the `openaiApiModel` setting.

This helps with using the extension with different AI service providers.

Closes #1300 