### PR TITLE
feat: Add new openai models to config enum in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1123,7 +1123,17 @@
             "gpt-4-0613",
             "gpt-4-32k",
             "gpt-4-32k-0314",
-            "gpt-4-32k-0613"
+            "gpt-4-32k-0613",
+            "gpt-4o-mini",
+            "gpt-4o-2024-05-13",
+            "gpt-4o",
+            "gpt-4.1-nano",
+            "gpt-4.1-mini",
+            "gpt-4.1",
+            "gpt-5",
+            "gpt-5-mini",
+            "gpt-5-nano",
+            "gpt-5-chat-latest"
           ],
           "description": "%config.openai_api_model%"
         },


### PR DESCRIPTION
This pull request updates the list of supported OpenAI models in the `package.json` file, expanding compatibility with newer and upcoming models.

Supported model updates:

* Added support for several new OpenAI models, including `gpt-4o-mini`, `gpt-4o-2024-05-13`, `gpt-4o`, `gpt-4.1-nano`, `gpt-4.1-mini`, `gpt-4.1`, `gpt-5`, `gpt-5-mini`, `gpt-5-nano`, and `gpt-5-chat-latest` to the allowed models list.