### PR TITLE
Add Support for glimmer-ts and glimmer-js files (Ember.js)

### DIFF
--- a/src/frameworks/ember.ts
+++ b/src/frameworks/ember.ts
@@ -17,6 +17,8 @@ class EmberFramework extends Framework {
     'javascriptreact',
     'typescriptreact',
     'handlebars',
+    'glimmer-ts',
+    'glimmer-js',
   ]
 
   // for visualize the regex, you can use https://regexper.com/

--- a/src/utils/LanguageId.ts
+++ b/src/utils/LanguageId.ts
@@ -21,6 +21,8 @@ export const LanguageIdExtMap = {
   blade: 'php',
   svelte: 'svelte',
   xml: 'xml',
+  'glimmer-js': 'gjs',
+  'glimmer-ts': 'gts',
 }
 
 export type LanguageId = keyof typeof LanguageIdExtMap


### PR DESCRIPTION
Glimmer-js (.gjs) and glimmer-ts (.gts) are the new authoring formats for Ember components (aka "Template Tag Syntax").

More information can be found here:
https://guides.emberjs.com/v5.6.0/components/template-tag-format/

This PR adds support for parsing .gts and .gjs files (the regex matching remains the same).


**Example of running this branch locally with these changes for the two main ways i18n is used in glimmer-js:**

<img width="719" height="133" alt="Screenshot 2025-11-14 at 8 38 12 AM" src="https://github.com/user-attachments/assets/76ffa143-7f86-425c-914d-5172af7df8bb" />


<img width="951" height="240" alt="Screenshot 2025-11-14 at 8 38 35 AM" src="https://github.com/user-attachments/assets/37f6b6c6-ae07-4aa0-8445-4d41f52c58cc" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Glimmer TypeScript (gts) file format
  * Added support for Glimmer JavaScript (gjs) file format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->