### PR TITLE
fix: pass DeepL auth token in authorization header (#1348)

### DIFF
--- a/src/translators/engines/deepl.ts
+++ b/src/translators/engines/deepl.ts
@@ -26,9 +26,7 @@ deepl.interceptors.request.use((req) => {
     ? 'https://api-free.deepl.com/v2'
     : 'https://api.deepl.com/v2'
 
-  req.params = {
-    auth_key: Config.deeplApiKey,
-  }
+  req.headers.Authorization = `DeepL-Auth-Key ${Config.deeplApiKey}`
 
   if (req.method === 'POST' || req.method === 'post') {
     req.headers['Content-Type'] = 'application/x-www-form-urlencoded'


### PR DESCRIPTION
Fixes #1348

Fixed according to DeepL recommendations: https://developers.deepl.com/docs/resources/breaking-changes-change-notices/november-2025-deprecation-of-legacy-auth-methods

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * DeepL API authentication now sends credentials via the Authorization header instead of a query parameter, improving API integration reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->