### PR TITLE
fix: use albania as default country for albanian

### DIFF
--- a/src/meta.ts
+++ b/src/meta.ts
@@ -30,5 +30,6 @@ export const DEFAULT_LOCALE_COUNTRY_MAP = {
   ja: 'ja',
   es: 'es',
   vi: 'vn',
-  lb: 'lu'
+  lb: 'lu',
+  sq: 'al'
 }


### PR DESCRIPTION
Adds `'sq': 'al'` to the default country locale map in src/meta.ts 